### PR TITLE
Fix typos in documentation

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ DESCRIPTION
     module that uses them completes its runtime. Like B::Hooks::EndOfScope
     except it triggers for run-time instead of compile-time.
 
-    Example where it might be handy:
+    An example where it might be handy:
 
         #!/usr/bin/perl
         use strict;
@@ -46,10 +46,10 @@ SYNOPSYS
         ....
 
         #EOF
-        # Package is now immutable autamatically
+        # Package is now immutable automatically
 
 CAVEATS
-    It is important to understand how Hook::AfterRuntime works n order to
+    It is important to understand how Hook::AfterRuntime works in order to
     know its limitations. When you use a module that calls after_runtime()
     in its import() method, after_runtime() will inject code directly after
     your import statement:
@@ -60,7 +60,7 @@ CAVEATS
 
         import MooseX::AutoImmute; my $__ENDRUNXXXXXXXX = Hook::AfterRuntime->new($id);
 
-    This creates a Hook::AfterRuntime object in the corrunt scope. This
+    This creates a Hook::AfterRuntime object in the current scope. This
     object's id is used to reference the code provided to after_runtime() in
     MooseX::AutoImmute()'s import() method. When the object falls out of
     scope the DESTROY() method kicks in and calls the referenced code. This
@@ -70,9 +70,9 @@ CAVEATS
     Loading in a scope other than package level:
         If you use the 'use' directive on a level other than the package
         level, the behavior will trigger when the end of the scope is
-        reached. If that is a subroutine than it will trigger at the end of
+        reached. If that is a subroutine then it will trigger at the end of
         EVERY call to that subroutine. You really should not import a class
-        using Hook::AfterRuntime outside tha package level scope.
+        using Hook::AfterRuntime outside the package level scope.
 
             package XXX;
 
@@ -80,7 +80,7 @@ CAVEATS
                 # Happens at compile time
                 use Object::Using::AfterRuntime;
 
-                # At run time the hook behavior triggers here!
+                # At runtime the hook behavior triggers here!
             }
 
             # hook behavior has not triggered
@@ -96,7 +96,7 @@ CAVEATS
             thus the hook is never installed.
 
     class->import
-            The hook effects the code that is currently compiling. calling
+            The hook affects the code that is currently compiling. Calling
             class->import happens after the compilation phase. You must wrap the
             statement in a BEGIN {} to call import manually. Failure to do this will
             result in the hook triggering in the wrong class, or not at all.
@@ -117,12 +117,12 @@ SEE ALSO
 
 FENNEC PROJECT
     This module is part of the Fennec project. See Fennec for more details.
-    Fennec is a project to develop an extendable and powerful testing
+    Fennec is a project to develop an extensible and powerful testing
     framework. Together the tools that make up the Fennec framework provide
     a potent testing environment.
 
     The tools provided by Fennec are also useful on their own. Sometimes a
-    tool created for Fennec is useful outside the greator framework. Such
+    tool created for Fennec is useful outside the creator framework. Such
     tools are turned into their own projects. This is one such project.
 
     Fennec - The core framework
@@ -134,10 +134,9 @@ AUTHORS
 COPYRIGHT
     Copyright (C) 2010 Chad Granum
 
-    Hook-AfterRuntime is free software; Standard perl licence.
+    Hook-AfterRuntime is free software; Standard Perl licence.
 
     Hook-AfterRuntime is distributed in the hope that it will be useful, but
     WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the license for
     more details.
-

--- a/lib/Hook/AfterRuntime.pm
+++ b/lib/Hook/AfterRuntime.pm
@@ -53,7 +53,7 @@ Useful for creating modules that need a behavior to be added when a module that
 uses them completes its runtime. Like L<B::Hooks::EndOfScope> except it
 triggers for run-time instead of compile-time.
 
-Example where it might be handy:
+An example where it might be handy:
 
     #!/usr/bin/perl
     use strict;
@@ -93,11 +93,11 @@ t/mytest.t
     ....
 
     #EOF
-    # Package is now immutable autamatically
+    # Package is now immutable automatically
 
 =head1 CAVEATS
 
-It is important to understand how Hook::AfterRuntime works n order to know its
+It is important to understand how Hook::AfterRuntime works in order to know its
 limitations. When you use a module that calls after_runtime() in its import()
 method, after_runtime() will inject code directly after your import statement:
 
@@ -107,7 +107,7 @@ becomes:
 
     import MooseX::AutoImmute; my $__ENDRUNXXXXXXXX = Hook::AfterRuntime->new($id);
 
-This creates a Hook::AfterRuntime object in the corrunt scope. This object's id
+This creates a Hook::AfterRuntime object in the current scope. This object's id
 is used to reference the code provided to after_runtime() in
 MooseX::AutoImmute()'s import() method. When the object falls out of scope the
 DESTROY() method kicks in and calls the referenced code. This occurs at the end
@@ -121,8 +121,8 @@ of the file when 'use' is called at the package level.
 
 If you use the 'use' directive on a level other than the package level, the
 behavior will trigger when the end of the scope is reached. If that is a
-subroutine than it will trigger at the end of EVERY call to that subroutine.
-B<You really should not import a class using Hook::AfterRuntime outside tha
+subroutine then it will trigger at the end of EVERY call to that subroutine.
+B<You really should not import a class using Hook::AfterRuntime outside the
 package level scope.>
 
     package XXX;
@@ -131,7 +131,7 @@ package level scope.>
         # Happens at compile time
         use Object::Using::AfterRuntime;
 
-        # At run time the hook behavior triggers here!
+        # At runtime the hook behavior triggers here!
     }
 
     # hook behavior has not triggered
@@ -149,7 +149,7 @@ package level scope.>
 
 =item class->import
 
-    The hook effects the code that is currently compiling. calling
+    The hook affects the code that is currently compiling. calling
     class->import happens after the compilation phase. You must wrap the
     statement in a BEGIN {} to call import manually. Failure to do this will
     result in the hook triggering in the wrong class, or not at all.
@@ -180,12 +180,12 @@ of run-time.
 =head1 FENNEC PROJECT
 
 This module is part of the Fennec project. See L<Fennec> for more details.
-Fennec is a project to develop an extendable and powerful testing framework.
+Fennec is a project to develop an extensible and powerful testing framework.
 Together the tools that make up the Fennec framework provide a potent testing
 environment.
 
 The tools provided by Fennec are also useful on their own. Sometimes a tool
-created for Fennec is useful outside the greator framework. Such tools are
+created for Fennec is useful outside the creator framework. Such tools are
 turned into their own projects. This is one such project.
 
 =over 2
@@ -204,7 +204,7 @@ Chad Granum L<exodist7@gmail.com>
 
 Copyright (C) 2010 Chad Granum
 
-Hook-AfterRuntime is free software; Standard perl licence.
+Hook-AfterRuntime is free software; Standard Perl licence.
 
 Hook-AfterRuntime is distributed in the hope that it will be useful, but WITHOUT
 ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS


### PR DESCRIPTION
While reading through the README I noticed a couple of typos.  These have been fixed in the README and the POD in this PR.  If you're not happy with this PR and want something changed, please just let me know and I'll update as appropriate and resubmit.