### PR TITLE
Ignore automatically generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Build
+MYMETA.json
+MYMETA.yml
+_build/
+blib/


### PR DESCRIPTION
After building the dist in order to run the test suite, I noticed that the automatically generated files weren't being ignored by git.  This patch ignores these files so as to remove unnecessary noise when using other git commands.  This PR is submitted in the hope that it is useful.  If you want anything changed, please just let me know and I'll update and resubmit as necessary.