### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm --installdeps . || { cat ~/.cpanm/build.log ; false ; }


### PR DESCRIPTION
This patch adds an initial [Travis-CI](https://travis-ci.org) configuration file.  Travis-CI is a free-for-open-source continuous integration service, enabling distributions to be built and tested automatically upon commits to GitHub.  As with my other patches, if you want anything changed, please just let me know and I'll update and resubmit as necessary.