### PR TITLE
Add initial App-Veyor configuration file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,14 @@
+cache:
+    - C:\Strawberry -> .appveyor_clear_cache.txt
+
+shallow_clone: true
+
+install:
+  - if not exist "C:\Strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_SLUG%
+  - cpanm --installdeps . || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+
+build_script:
+  - perl Build.PL
+  - ./Build test


### PR DESCRIPTION
Similarly to Travis-CI, [AppVeyor](https://ci.appveyor.com) is a contiuous integration service which is free for open source projects.  However, unlike Travis, it allows builds on Windows, hence this patch makes it possible to automatically build and test the dist on Windows as well as Linux (on Travis).