### PR TITLE
Specify minimum required Perl version

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -10,6 +10,7 @@ my $build = Module::Build->new(
     dist_author => 'Chad Granum <exodist7@gmail.com>',
     create_readme => 1,
     requires => {
+        'perl' => '5.006',
         'Exporter' => 5.57,
         'B::Hooks::Parser' => '0.09',
     },

--- a/lib/Hook/AfterRuntime.pm
+++ b/lib/Hook/AfterRuntime.pm
@@ -1,6 +1,7 @@
 package Hook::AfterRuntime;
 use strict;
 use warnings;
+use 5.006;
 
 use B::Hooks::Parser;
 use base 'Exporter';


### PR DESCRIPTION
It is considered good practice to specify the minimum Perl version so
that tools such as cpanm and CPANTesters can work correctly.